### PR TITLE
Fix damage calculation in poker battle game

### DIFF
--- a/TANAKA Mako.c
+++ b/TANAKA Mako.c
@@ -655,19 +655,34 @@ int main(void)
 
         if (player_score > cpu_score)
         {
-            int damage = cpu_score / penalty_divisor;
-            cpu.hp -= damage;
-            printf("あなたの勝ち! CPUに%dダメージ\n", damage);
+            int win_dmg = player_score;
+            int lose_dmg = cpu_score / penalty_divisor;
+            cpu.hp -= win_dmg;
+            player.hp -= lose_dmg;
+            printf("あなたの勝ち! CPUに%dダメージ\n", win_dmg);
+            if (lose_dmg > 0)
+            {
+                printf("CPUからの反撃! あなたは%dダメージ\n", lose_dmg);
+            }
         }
         else if (cpu_score > player_score)
         {
-            int damage = player_score / penalty_divisor;
-            player.hp -= damage;
-            printf("CPUの勝ち! あなたは%dダメージ\n", damage);
+            int win_dmg = cpu_score;
+            int lose_dmg = player_score / penalty_divisor;
+            player.hp -= win_dmg;
+            cpu.hp -= lose_dmg;
+            printf("CPUの勝ち! あなたは%dダメージ\n", win_dmg);
+            if (lose_dmg > 0)
+            {
+                printf("あなたの反撃! CPUは%dダメージ\n", lose_dmg);
+            }
         }
         else
         {
-            printf("引き分け! ダメージなし\n");
+            int damage = player_score; /* cpu_score と同じ */
+            player.hp -= damage;
+            cpu.hp -= damage;
+            printf("引き分け! お互い%dダメージ\n", damage);
         }
 
         printf("あなたのHP : %d\n", player.hp);


### PR DESCRIPTION
## Summary
- calculate battle damage correctly based on hand strength
- loser now deals reduced damage instead of none
- both players take damage on ties

## Testing
- `gcc -std=c11 -Wall -Wextra -o a.out 'TANAKA Mako.c'`

------
https://chatgpt.com/codex/tasks/task_e_68559303f5f8832581fcec25a508c9a2